### PR TITLE
Assume only one DB and Load component resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,18 +5,15 @@ application rgbank (
   $use_docker = false,
 ) {
 
-  $db_components = collect_component_titles($nodes, Rgbank::Db)
+  $db_component = collect_component_titles($nodes, Rgbank::Db)[0] #Assume we only have one
   $web_components = collect_component_titles($nodes, Rgbank::Web)
-  $load_components = collect_component_titles($nodes, Rgbank::Load)
+  $load_component = collect_component_titles($nodes, Rgbank::Load)[0] #Assume we only have one
   $vinfrastructure_components = collect_component_titles($nodes, Rgbank::Infrastructure::Web)
 
-  #Assume we only have one DB component
-  if $db_components.size() > 0 {
-    rgbank::db { $db_components[0]:
-      user     => $db_username,
-      password => $db_password,
-      export   => Database[$db_components[0]],
-    }
+  rgbank::db { $db_component:
+    user     => $db_username,
+    password => $db_password,
+    export   => Database[$db_components[0]],
   }
 
   $web_https = $web_components.map |$comp_name| {
@@ -44,13 +41,10 @@ application rgbank (
     $http
   }
 
-  if $load_components.size() > 0 {
-    #Assume we only have one load balancer component
-    rgbank::load { $load_components[0]:
-      balancermembers => $web_https,
-      port            => $serve_port,
-      require         => $web_https,
-      export          => Http[$load_components[0]],
-    }
+  rgbank::load { $load_component:
+    balancermembers => $web_https,
+    port            => $serve_port,
+    require         => $web_https,
+    export          => Http[$load_components[0]],
   }
 }


### PR DESCRIPTION
Previous to this commit, an array of load balancer and DB components
were generated and iterated over, with the obscure assumption there
would only be one iteration.  This was horribly confusing to read.

This commit moves the assumption to collection of the components, only
returning the first element of the array. This means only one component
resource has to be declared.  Much cleaner
