### PR TITLE
Fix db resources

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -1,7 +1,7 @@
 define rgbank::db (
   $user,
   $password,
-  $mock_sql_source = hiera('rgbank-mock-sql-path', ''),
+  $mock_sql_source = hiera('rgbank-mock-sql-path', 'https://raw.githubusercontent.com/puppetlabs/rgbank/master/rgbank.sql'),
 ) {
   $db_name = "rgbank-${name}"
 

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -1,6 +1,7 @@
 define rgbank::db (
   $user,
   $password,
+  $port = '3306',
   $mock_sql_source = hiera('rgbank-mock-sql-path', 'https://raw.githubusercontent.com/puppetlabs/rgbank/master/rgbank.sql'),
 ) {
   $db_name = "rgbank-${name}"
@@ -37,5 +38,6 @@ Rgbank::Db produces Database {
     undef   => $::networking['interfaces'][$::networking['interfaces'].keys[0]]['ip'],
     default => $ec2_metadata['public-ipv4'],
   },
-  password => $password
+  password => $password,
+  port     => $port,
 }


### PR DESCRIPTION
The default database service resource from app_modeling uses postgresql port (5432).  Updating to use 3306 since this module uses MySQL.  Also setting the default SQL import file location.
