### PR TITLE
Updating web::base for github source

### DIFF
--- a/manifests/web/base.pp
+++ b/manifests/web/base.pp
@@ -18,12 +18,28 @@ define rgbank::web::base(
   }
 
   if $source =~ /^https:\/\/github.com/ {
-    vcsrepo { "${install_dir_real}/wp-content/themes/rgbank":
+
+    file { "${install_dir_real}/git":
+      ensure => directory,
+      owner  => root,
+      group  => root,
+      mode   => '0755',
+    }
+
+    vcsrepo { "${install_dir_real}/git/rgbank":
       ensure   => present,
       provider => git,
       source   => $source,
       revision => $version,
+      require  => File["${install_dir_real}/git"],
     }
+
+    file { "${install_dir_real}/wp-content/themes/rgbank":
+      ensure  => link,
+      target  => "${install_dir_real}/git/rgbank/src",
+      require => Vcsrepo["${install_dir_real}/git/rgbank"],
+    }
+
   } else {
     archive { "rgbank-build-${version}-${name}":
       ensure     => present,


### PR DESCRIPTION
Prior to this commit the vcsrepo would checkout the rgbank git repo
into the theme directory.  The problem was that there are
subdirectories that are not present in the Jenkins built artifacts.
This commit creates a staging area to checkout git to and then sets
a symlink in the themes directory that points to the git repo src
folder
