### PR TITLE
Adding mysql::server to db component

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -3,6 +3,15 @@ define rgbank::db (
   $password,
   $mock_sql_source = hiera('rgbank-mock-sql-path', ''),
 ) {
+
+  class { '::mysql::server':
+    override_options => {
+      'mysqld' => {
+        'bind-address' => '0.0.0.0',
+      },
+    },
+  }
+
   $db_name = "rgbank-${name}"
 
   file { "/var/lib/${db_name}":


### PR DESCRIPTION
Prior to this commit the db component required a profile to be
previously applied to the server to install mysql server.  In
production scenarios, this will be required. Given we are looking
to generalize this module and share with others we should probably
handle this prereq
