### PR TITLE
SELinux, Listen Port Changes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,7 @@ application rgbank (
 
   rgbank::load { $load_component:
     balancermembers => $web_https,
-    port            => $serve_port,
+    port            => $listen_port,
     require         => $web_https,
     export          => Http[$load_component],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,9 @@
 application rgbank (
   $db_username = 'test',
   $db_password = 'test',
-  $listen_port = '80',
-  $use_docker = false,
+  $listen_port = '8060',
+  $use_docker  = false,
+  $lb_port     = '80',
 ) {
 
   $db_component = collect_component_titles($nodes, Rgbank::Db)[0] #Assume we only have one
@@ -31,7 +32,7 @@ application rgbank (
 
   rgbank::load { $load_component:
     balancermembers => $web_https,
-    port            => $listen_port,
+    port            => $lb_port,
     require         => $web_https,
     export          => Http[$load_component],
   }

--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -31,12 +31,15 @@ define rgbank::load (
 
     $member_port = $member['port']
     $port_name = "allow-httpd-${member_port}"
-    if ! defined(Selinux::Port[$port_name]) {
-      selinux::port { $port_name:
-        context  => 'http_port_t',
-        port     => $member['port'],
-        protocol => 'tcp',
-        before   => Haproxy::Listen["rgbank-${name}"],
+
+    if $::selinux == true {
+      if ! defined(Selinux::Port[$port_name]) {
+        selinux::port { $port_name:
+          context  => 'http_port_t',
+          port     => $member['port'],
+          protocol => 'tcp',
+          before   => Haproxy::Listen["rgbank-${name}"],
+        }
       }
     }
   }

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -31,7 +31,7 @@ define rgbank::web (
       install_dir => $install_dir,
     }
 
-    if $selinux {
+    if $::selinux == true {
       if (! defined(Selinux::Port["allow-httpd-${listen_port}"])) {
         selinux::port { "allow-httpd-${listen_port}":
           context  => 'http_port_t',
@@ -41,11 +41,11 @@ define rgbank::web (
         }
       }
 
-      if (! defined(Selinux::Boolean["httpd_can_network_connect"])) {
+      if (! defined(Selinux::Boolean['httpd_can_network_connect'])) {
         selinux::boolean { 'httpd_can_network_connect':
           ensure     => true,
           persistent => true,
-          before   => [Apache::Listen[$listen_port],Apache::Vhost[$::fqdn]],
+          before     => [Apache::Listen[$listen_port],Apache::Vhost[$::fqdn]],
         }
       }
     }


### PR DESCRIPTION
Updating to use the selinux fact in a Puppet 4 Compatible way.
Updating the listen_port configurations for haproxy, apache
Fixing base.pp ordering (previously we tried to manage the themes directory before actually installing wordpress - which is fallout from adjusting how we handle non-jenkins deploys)
