### PR TITLE
Add OpenStack Acceptance Tests, Update SELINUX

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,9 +32,10 @@ group :development, :unit_tests do
   gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
 end
 group :system_tests do
-  gem 'beaker', *location_from_env('BEAKER_VERSION', []) if RUBY_VERSION >= '2.3.0'
-  gem 'beaker', *location_from_env('BEAKER_VERSION', ['< 3']) if RUBY_VERSION < '2.3.0'
-  gem 'beaker-rspec', *location_from_env('BEAKER_RSPEC_VERSION', ['>= 3.4'])
+  gem 'beaker',       :git => 'https://github.com/ipcrm/beaker.git',
+                      :ref => 'a60391e0dc257b87ff372bbffd424d1c46e4b55d'
+  gem 'beaker-rspec', :git => 'https://github.com/hunner/beaker-rspec.git',
+                      :ref => '755b3bfc6f8d661ab8c11838997890acd7875ab1'
   gem 'serverspec'
   gem 'beaker-puppet_install_helper'
   gem 'master_manipulator'

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -21,14 +21,14 @@ define rgbank::web (
     }
   } else {
     rgbank::web::base { $name:
-      db_name          => $db_name,
-      db_user          => $db_user,
-      db_password      => $db_password,
-      db_host          => $db_host,
-      version          => $version,
-      source           => $source,
-      listen_port      => $listen_port,
-      install_dir      => $install_dir,
+      db_name     => $db_name,
+      db_user     => $db_user,
+      db_password => $db_password,
+      db_host     => $db_host,
+      version     => $version,
+      source      => $source,
+      listen_port => $listen_port,
+      install_dir => $install_dir,
     }
 
     if $::selinux == true {

--- a/manifests/web/base.pp
+++ b/manifests/web/base.pp
@@ -88,6 +88,16 @@ define rgbank::web::base(
     require => Wordpress::Instance::App["rgbank_${name}"],
   }
 
+  if $::selinux == true {
+    exec{"selinux-update-${install_dir_real}":
+      path        => $::path,
+      command     => "chcon -R system_u:object_r:usr_t:s0 ${install_dir_real}",
+      subscribe   => Wordpress::Instance::App["rgbank_${name}"],
+      refreshonly => true,
+      require     => File["${install_dir_real}/wp-content/uploads"],
+    }
+  }
+
   apache::listen { $listen_port: }
 
   if (! defined(Apache::Vhost[$::fqdn])) {

--- a/spec/acceptance/nodesets/centos7-openstack.yml
+++ b/spec/acceptance/nodesets/centos7-openstack.yml
@@ -1,0 +1,26 @@
+HOSTS:
+  centos-7-openstack:
+    roles:
+      - agent
+      - default
+    platform: el-7-x86_64
+    image: centos_7_x86_64
+    flavor: d1.small
+    hypervisor: openstack
+    user_data: |
+      #!/bin/bash
+      sed -i 's/Defaults    requiretty//g' /etc/sudoers
+      echo 0 > /sys/fs/selinux/enforce
+      unalias cp
+      cp -fpr ~centos/.ssh/authorized_keys ~root/.ssh/
+      chown root: ~root/.ssh/authorized_keys
+      sed -i 's/^#PermitRootLogin/PermitRootLogin/g' /etc/ssh/sshd_config
+      service sshd restart
+CONFIG:
+  log_level: debug
+  type: foss
+  nfs_server: none
+  security_group: ['sg0', 'default']
+  floating_ip_pool: 'ext-net-pdx1-opdx1'
+  openstack_volume_support: false
+  openstack_network : 'network0'

--- a/spec/acceptance/nodesets/centos7-openstack.yml
+++ b/spec/acceptance/nodesets/centos7-openstack.yml
@@ -17,7 +17,7 @@ HOSTS:
       sed -i 's/^#PermitRootLogin/PermitRootLogin/g' /etc/ssh/sshd_config
       service sshd restart
 CONFIG:
-  log_level: debug
+ # log_level: debug
   type: foss
   nfs_server: none
   security_group: ['sg0', 'default']

--- a/spec/acceptance/rgbank_2web_spec.rb
+++ b/spec/acceptance/rgbank_2web_spec.rb
@@ -6,6 +6,7 @@ describe 'rgbank web define' do
       # Using puppet_apply as a helper
       it 'should work idempotently with no errors' do
         pp = <<-EOS
+        package {'wget': ensure => present, }
         class { 'apache': default_vhost => false, }
         class { 'apache::mod::php': }
         class {'::mysql::client': }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,7 +2,6 @@ require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker/puppet_install_helper'
 
-run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 install_puppet_agent_on(hosts, :version => '1.7.0')
 
 RSpec.configure do |c|


### PR DESCRIPTION
- Adding CentOS7 Acceptance testing that runs on OpenStack
- Updating SELinux handling to fix idempotent issue
- Cleaned up acceptance helper to stop installing Puppet multiple times
- Updating Gemfile to pin to fork/commits until other PRs merged 

https://github.com/puppetlabs/beaker-rspec/pull/86
https://github.com/puppetlabs/beaker/pull/1264
