### PR TITLE
Use parallel_tests 2.9.0 for ruby < 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development, :unit_tests do
   gem 'rspec-puppet', '>= 2.4.0', :git => 'https://github.com/rodjek/rspec-puppet.git',
                                   :ref => 'd1a7233eec08a2c605b623ced2b863c5ea4b37df'
   gem 'rspec-puppet-facts'
-  gem 'parallel_tests'
+  gem 'parallel_tests', '2.9.0' if RUBY_VERSION < '2.0.0'
   gem 'rubocop', '0.41.2' if RUBY_VERSION < '2.0.0'
   gem 'rubocop' if RUBY_VERSION >= '2.0.0'
   gem 'rubocop-rspec', '~> 1.6' if RUBY_VERSION >= '2.3.0'


### PR DESCRIPTION
Parallel_tests 2.10.0 requires ruby >= 2.0.0, so for jobs with
ruby < 2.0.0 parallel_tests 2.9.0 should be used.
